### PR TITLE
Allow for mPower Mini and mPower Pro

### DIFF
--- a/mqtt/client/mqpub-static.sh
+++ b/mqtt/client/mqpub-static.sh
@@ -5,7 +5,7 @@ $PUBBIN -h $mqtthost $auth -t $topic/\$name -m "$devicename" -r
 $PUBBIN -h $mqtthost $auth -t $topic/\$fw/version -m "$version" -r
 
 # identify mFi device
-export mFiType=`cat /etc/board.inc | grep board_name | sed -e 's/.*="\(.*\)";/\1/'`
+export mFiType=`cat /etc/board.inc | grep board_name | sed -e 's/.*="\(.*\)";/\1/' | cut -d" " -f1`
 
 $PUBBIN -h $mqtthost $auth -t $topic/\$fw/name -m "mFi MQTT" -r
 

--- a/mqtt/client/mqpub.sh
+++ b/mqtt/client/mqpub.sh
@@ -9,7 +9,7 @@ source $BIN_PATH/client/mpower-pub.cfg
 export PUBBIN=$BIN_PATH/mosquitto_pub
 
 # identify mFi device
-export mFiType=`cat /etc/board.inc | grep board_name | sed -e 's/.*="\(.*\)";/\1/'`
+export mFiType=`cat /etc/board.inc | grep board_name | sed -e 's/.*="\(.*\)";/\1/' | cut -d" " -f1`
 
 log "mFi Type: $mFiType."
 


### PR DESCRIPTION
The one port mPower's board_name is "mPower mini", the eight port one is "mPower PRO". This change will truncate $mFiType to just the first word. Thus the comparison on line 17 will succeed and the device wil work with the correct number of ports.